### PR TITLE
Fix rustfmt and clippy complaints

### DIFF
--- a/src/cmds/clan.rs
+++ b/src/cmds/clan.rs
@@ -45,7 +45,7 @@ pub async fn clan(
     #[description = "clan's tag or name"]
     #[autocomplete = "auto_complete::clan"]
     clan: String,
-    #[description = "specify season of Clan Battle, -1 for the latest season"] season: Option<i64>,
+    #[description = "specify season of Clan Battle, -1 for the latest season"] season: Option<i32>,
 ) -> Result<(), Error> {
     let auto_complete_clan: AutoCompleteClan =
         serde_json::from_str(&clan).map_err(|_| IsacError::Info(IsacInfo::AutoCompleteError))?;
@@ -59,7 +59,7 @@ pub async fn clan(
         let current_season_num = ctx.data().constant.read().clan_season;
         let season = match season.is_positive() {
             false => current_season_num,
-            true => season.unsigned_abs() as u32,
+            true => season.unsigned_abs(),
         };
         func_clan_season(&ctx, partial_clan, season).await
     } else {

--- a/src/cmds/clan.rs
+++ b/src/cmds/clan.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    fmt::Write,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -58,7 +59,7 @@ pub async fn clan(
         let current_season_num = ctx.data().constant.read().clan_season;
         let season = match season.is_positive() {
             false => current_season_num,
-            true => season.abs() as u32,
+            true => season.unsigned_abs() as u32,
         };
         func_clan_season(&ctx, partial_clan, season).await
     } else {
@@ -159,7 +160,7 @@ async fn func_clan(ctx: &Context<'_>, partial_clan: PartialClan) -> Result<(), E
         // filter only the latest 4 seasons' best rating
         .filter(|f| {
             ((current_season_num - 3)..=current_season_num).contains(&f.season_number)
-                && f.is_best_season_rating == true
+                && f.is_best_season_rating
         })
         .sorted_by_key(|f| -(f.season_number as i32))
         .map(|f| f.into())
@@ -196,7 +197,7 @@ async fn func_clan(ctx: &Context<'_>, partial_clan: PartialClan) -> Result<(), E
         .into_message()
         .await?;
     typing.stop();
-    view.interactions(&ctx, ctx.author().id, msg).await?;
+    view.interactions(ctx, ctx.author().id, msg).await?;
     Ok(())
 }
 
@@ -289,7 +290,7 @@ impl ClanView {
         mut msg: Message,
     ) -> Result<(), Error> {
         while let Some(interaction) = msg
-            .await_component_interactions(&ctx)
+            .await_component_interactions(ctx)
             .timeout(Duration::from_secs(60))
             .build()
             .next()
@@ -332,11 +333,11 @@ impl ClanView {
     }
 
     fn members_table(&self) -> String {
-        let members: String = self
+        let members = self
             .members
             .iter()
             .sorted_by_key(|m| m.ign.to_lowercase())
-            .map(|m| {
+            .fold(String::new(), |mut buf, m| {
                 let (winrate, dmg, battles) = if m.battles == 0 {
                     ("-".to_string(), "-".to_string(), "-".to_string())
                 } else {
@@ -347,9 +348,9 @@ impl ClanView {
                     )
                 };
 
-                format!("{:24} {:>6} {:>6} {:>6}\n", m.ign, winrate, dmg, battles)
-            })
-            .collect();
+                let _ = writeln!(buf, "{:24} {:>6} {:>6} {:>6}", m.ign, winrate, dmg, battles);
+                buf
+            });
         format!(
             "```{:24} {:>6} {:>6} {:>6}\n{:-<24} {:->6} {:->6} {:->6}\n{members}```",
             "ign", "WR", "DMG", "BTL", "", "", "", ""

--- a/src/cmds/clan_top.rs
+++ b/src/cmds/clan_top.rs
@@ -91,7 +91,7 @@ impl ClanTopView {
         mut msg: Message,
     ) -> Result<(), Error> {
         while let Some(interaction) = msg
-            .await_component_interactions(&ctx)
+            .await_component_interactions(ctx)
             .timeout(Duration::from_secs(60))
             .author_id(author)
             .build()
@@ -144,7 +144,7 @@ impl ClanTopView {
         for clan in res_clans {
             let name = format!(
                 "[{}]    rating: {}",
-                clan.tag.replace("_", r"\_"),
+                clan.tag.replace('_', r"\_"),
                 clan.division_rating
             );
             let timestamp = DateTime::parse_from_str(&clan.last_battle_at, "%Y-%m-%d %H:%M:%S%z")

--- a/src/cmds/leaderboard.rs
+++ b/src/cmds/leaderboard.rs
@@ -160,7 +160,9 @@ pub async fn fetch_ship_leaderboard(
     // Find the ranking table
     let table_selector = Selector::parse(".ranking-table").unwrap();
     let Some(table) = html.select(&table_selector).skip(5).next() else {
-        Err(IsacInfo::GeneralError { msg: format!("❌ No one on the leaderboard of `{}` yet", ship.name) })?
+        Err(IsacInfo::GeneralError {
+            msg: format!("❌ No one on the leaderboard of `{}` yet", ship.name),
+        })?
     };
 
     // Parse cells in the table

--- a/src/cmds/leaderboard.rs
+++ b/src/cmds/leaderboard.rs
@@ -159,7 +159,7 @@ pub async fn fetch_ship_leaderboard(
     let html = Html::parse_document(&res_text);
     // Find the ranking table
     let table_selector = Selector::parse(".ranking-table").unwrap();
-    let Some(table) = html.select(&table_selector).skip(5).next() else {
+    let Some(table) = html.select(&table_selector).nth(5) else {
         Err(IsacInfo::GeneralError {
             msg: format!("❌ No one on the leaderboard of `{}` yet", ship.name),
         })?
@@ -179,7 +179,7 @@ pub async fn fetch_ship_leaderboard(
     let get_color_value = |element: ElementRef<'_>| -> StatisticValue {
         let span = element.select(&span_selector).next().unwrap();
         let color = color_re
-            .captures(&span.value().attr("style").unwrap())
+            .captures(span.value().attr("style").unwrap())
             .unwrap()
             .get(0)
             .unwrap()
@@ -226,7 +226,7 @@ pub async fn fetch_ship_leaderboard(
         let (clan, (uid, ign)) = if value_1.len() == 2 {
             let clan = value_1[0].text().collect::<String>();
             let value = value_1[1].value();
-            (clan, get_uid_and_ign(&value))
+            (clan, get_uid_and_ign(value))
         } else {
             ("".to_string(), get_uid_and_ign(value_1[0].value()))
         };

--- a/src/cmds/wws.rs
+++ b/src/cmds/wws.rs
@@ -177,7 +177,7 @@ pub async fn func_wws(ctx: &Context<'_>, partial_player: PartialPlayer) -> Resul
     );
     let class: OverallTemplateClass = ships
         .clone()
-        .sort_class(&ctx)
+        .sort_class(ctx)
         .into_iter()
         .map(|(class, ships)| {
             (
@@ -190,7 +190,7 @@ pub async fn func_wws(ctx: &Context<'_>, partial_player: PartialPlayer) -> Resul
         .collect::<HashMap<ShipClass, Statistic>>()
         .into();
     let tier: OverallTemplateTier = ships
-        .sort_tier(&ctx)
+        .sort_tier(ctx)
         .into_iter()
         .map(|(class, ships)| {
             (

--- a/src/dc_utils/args.rs
+++ b/src/dc_utils/args.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, time::Duration};
+use std::{fmt::Write, str::FromStr, time::Duration};
 
 use itertools::Itertools;
 use once_cell::sync::Lazy;
@@ -232,9 +232,9 @@ impl Args {
 impl FromStr for Args {
     type Err = IsacError;
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        const RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#""[^"]+"|\S+"#).unwrap());
+        static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#""[^"]+"|\S+"#).unwrap());
         Ok(Args(
-            RE.find_iter(&input)
+            RE.find_iter(input)
                 .map(|s| s.as_str().trim_matches('"').to_string())
                 .collect(),
         ))
@@ -269,12 +269,13 @@ impl<'a, T: std::fmt::Display> PickView<'a, T> {
             .name(&self.user.name)
             .icon_url(self.user.avatar_url().unwrap_or_default());
 
-        let mut msg_text = self
-            .candidates
-            .iter()
-            .enumerate()
-            .map(|(index, candidate)| format!("{} {}\n\n", self.emoji[index], candidate))
-            .collect::<String>();
+        let mut msg_text = self.candidates.iter().enumerate().fold(
+            String::new(),
+            |mut buf, (index, candidate)| {
+                let _ = writeln!(buf, "{} {}\n", self.emoji[index], candidate);
+                buf
+            },
+        );
 
         msg_text += &format!("{} None of above", self.x_emoji);
 

--- a/src/dc_utils/user.rs
+++ b/src/dc_utils/user.rs
@@ -37,7 +37,7 @@ pub trait UserAddon: Sized {
         ctx.http()
             .get_member(guild_id.0, ctx.author().id.0)
             .await?
-            .permissions(&ctx.cache().ok_or::<Error>("get cache failed".into())?)
+            .permissions(ctx.cache().ok_or::<Error>("get cache failed".into())?)
             .map_err(|err| err.into())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+// Using enum unqualified is bad form. See https://youtu.be/8j_FbjiowvE?t=97.
+#![deny(clippy::enum_glob_use)]
+
 mod cmds;
 use cmds::*;
 mod dc_utils;

--- a/src/template_data/single_ship.rs
+++ b/src/template_data/single_ship.rs
@@ -61,6 +61,7 @@ impl SingleShipTemplate {
     }
     // QA 這種方式真的算正面嗎?
     /// a helper function to build up the structure, raise [`IsacInfo::PlayerNoBattleShip`] if the main_mode battle_counts is 0
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ctx: &Context<'_>,
         ship: Ship,

--- a/src/template_data/single_ship.rs
+++ b/src/template_data/single_ship.rs
@@ -72,7 +72,8 @@ impl SingleShipTemplate {
         clan: Option<PartialClan>,
         player: Player,
     ) -> Result<Self, IsacError> {
-        let Some(main_mode) = ship_stats.to_statistic(&ship_id, &ctx.data().expected_js, mode) else {
+        let Some(main_mode) = ship_stats.to_statistic(&ship_id, &ctx.data().expected_js, mode)
+        else {
             Err(IsacInfo::PlayerNoBattleShip {
                 ign: player.ign.clone(),
                 ship_name: ship.name.clone(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,7 @@ pub trait LoadSaveFromJson {
     {
         tokio::task::spawn_blocking(move || {
             let reader = std::io::BufReader::new(
-                std::fs::File::open(&Self::PATH)
+                std::fs::File::open(Self::PATH)
                     .unwrap_or_else(|_| panic!("Failed to open file: {}", Self::PATH)),
             );
             serde_json::from_reader(reader)
@@ -45,7 +45,7 @@ pub trait LoadSaveFromJson {
     where
         Self: DeserializeOwned + Serialize + Default,
     {
-        if let Ok(file) = std::fs::File::open(&Self::PATH) {
+        if let Ok(file) = std::fs::File::open(Self::PATH) {
             let reader = std::io::BufReader::new(file);
             serde_json::from_reader(reader).unwrap_or_else(|err| {
                 panic!(
@@ -98,7 +98,7 @@ pub trait LoadSaveFromJson {
         if let Some(parent_dir) = std::path::Path::new(Self::PATH).parent() {
             fs::create_dir_all(parent_dir).unwrap();
         }
-        let file = std::fs::File::create(&Self::PATH)
+        let file = std::fs::File::create(Self::PATH)
             .unwrap_or_else(|err| panic!("failed to create file: {:?}, Err: {err}", Self::PATH));
         serde_json::to_writer(file, &self).unwrap_or_else(|err| {
             panic!(

--- a/src/utils/error_handler.rs
+++ b/src/utils/error_handler.rs
@@ -32,8 +32,8 @@ pub async fn isac_err_handler(ctx: &Context<'_>, error: &IsacError) {
         }
         IsacError::Cancelled => (),
         IsacError::UnknownError(err) => {
-            isac_err_logging(&ctx, err).await;
-            isac_get_help(&ctx, None).await
+            isac_err_logging(ctx, err).await;
+            isac_get_help(ctx, None).await
         }
     };
 }

--- a/src/utils/isac_error.rs
+++ b/src/utils/isac_error.rs
@@ -130,12 +130,12 @@ impl Display for IsacInfo {
             }
             IsacInfo::ClanNoBattle { clan, season } => format!(
                 "**[{}]** ({}) did not participate in season **{}**",
-                clan.tag.replace("_", r"\_"),
+                clan.tag.replace('_', r"\_"),
                 clan.region,
                 season
             ),
             IsacInfo::NeedPremium { msg } => format!("{msg}\n{PREMIUM}"),
-            IsacInfo::EmbedPermission => format!("❌ This error means ISAC don't have to permission to send embed here, please check the **Embed Links** in the permission setting, \nOr you can just re-invite ISAC in discord to let it grant the permission"),
+            IsacInfo::EmbedPermission => "❌ This error means ISAC don't have to permission to send embed here, please check the **Embed Links** in the permission setting, \nOr you can just re-invite ISAC in discord to let it grant the permission".to_string(),
         };
         write!(f, "{}", msg)
     }

--- a/src/utils/structs/clan.rs
+++ b/src/utils/structs/clan.rs
@@ -29,7 +29,7 @@ impl PartialClan {
         self.region.number_url(format!(
             "/clan/{},{}/",
             self.id,
-            self.name.replace(" ", "-")
+            self.name.replace(' ', "-")
         ))
     }
 
@@ -238,6 +238,7 @@ impl ClanLeague {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Serialize, Deserialize_repr, Debug, Eq, PartialEq, Hash, Default)]
 #[repr(u8)]
 pub enum ClanDivision {

--- a/src/utils/structs/clan.rs
+++ b/src/utils/structs/clan.rs
@@ -63,11 +63,15 @@ impl PartialClan {
                 msg: s.as_ref().into(),
             }
         }
-        let "ok" = json.get("status").and_then(|f|f.as_str()).unwrap() else {
+        let "ok" = json.get("status").and_then(|f| f.as_str()).unwrap() else {
             let err_msg = json.get("error").and_then(|f| f.as_str());
             match err_msg {
-                Some(err) => Err(IsacInfo::APIError { msg:err.to_string() })?,
-                None => Err(IsacInfo::GeneralError { msg: "parsing player's clan failed".to_string() })?
+                Some(err) => Err(IsacInfo::APIError {
+                    msg: err.to_string(),
+                })?,
+                None => Err(IsacInfo::GeneralError {
+                    msg: "parsing player's clan failed".to_string(),
+                })?,
             }
         };
         let sec_layer = json.get("data").ok_or(err("no data"))?;

--- a/src/utils/structs/dogtag.rs
+++ b/src/utils/structs/dogtag.rs
@@ -6,6 +6,8 @@ use serde_with::{serde_as, DisplayFromStr};
 
 use crate::utils::LoadSaveFromJson;
 
+static DOGTAGS: Lazy<HashMap<u64, DogtagData>> = Lazy::new(|| Dogtag::load_json_sync().into());
+
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Dogtag(pub HashMap<u64, DogtagData>);
 
@@ -14,12 +16,11 @@ impl LoadSaveFromJson for Dogtag {
 }
 
 impl Dogtag {
-    const DOGTAG: Lazy<HashMap<u64, DogtagData>> = Lazy::new(|| Dogtag::load_json_sync().into());
     pub fn get(input: u64) -> Option<String> {
         if input == 0 {
             None
         } else {
-            Self::DOGTAG
+            DOGTAGS
                 .get(&input)
                 .map(|f| f.icons.small.clone().unwrap_or_default())
         }

--- a/src/utils/structs/player.rs
+++ b/src/utils/structs/player.rs
@@ -85,8 +85,14 @@ impl Player {
     /// parsing player from returned json
     pub async fn parse(data: &Data, region: Region, input: Value) -> Result<Player, IsacError> {
         let first_layer = input.as_object().unwrap();
-        let "ok" = first_layer.get("status").and_then(|f|f.as_str()).unwrap() else {
-            Err(IsacInfo::APIError { msg: first_layer.get("error").and_then(|f| f.as_str()).unwrap().to_string() })?
+        let "ok" = first_layer.get("status").and_then(|f| f.as_str()).unwrap() else {
+            Err(IsacInfo::APIError {
+                msg: first_layer
+                    .get("error")
+                    .and_then(|f| f.as_str())
+                    .unwrap()
+                    .to_string(),
+            })?
         };
         let (uid, sec_layer) = first_layer
             .get("data")

--- a/src/utils/structs/player.rs
+++ b/src/utils/structs/player.rs
@@ -205,7 +205,7 @@ pub struct PfpData {
 
 impl Default for PfpData {
     fn default() -> Self {
-        const DEFAULT_PFBG: &'static str = "https://cdn.discordapp.com/attachments/483227767685775360/1117119650052972665/image.png";
+        const DEFAULT_PFBG: &str = "https://cdn.discordapp.com/attachments/483227767685775360/1117119650052972665/image.png";
         Self {
             url: DEFAULT_PFBG.to_string(),
             name: "".to_string(),

--- a/src/utils/structs/recent.rs
+++ b/src/utils/structs/recent.rs
@@ -75,13 +75,13 @@ impl RecentPlayer {
 
     /// init new player file
     pub async fn init(player: &PartialPlayer) -> Self {
-        let data = Self {
+        
+        Self {
             player: *player,
             last_update_at: 0,
             last_request: RecentPlayerType::Normal(0),
             data: Default::default(),
-        };
-        data
+        }
     }
 
     /// save player data

--- a/src/utils/structs/ship.rs
+++ b/src/utils/structs/ship.rs
@@ -277,19 +277,24 @@ impl ShipStatsCollection {
         use StatisticValueType as S;
         let winrate = S::Winrate {
             value: ttl_wins as f64 / battles as f64 * 100.0,
-        };
+        }
+        .into();
         let dmg = S::OverallDmg {
             value: ttl_dmg as f64 / battles as f64,
-        };
+        }
+        .into();
         let frags = S::Frags {
             value: ttl_frags as f64 / battles as f64,
-        };
+        }
+        .into();
         let planes = S::Planes {
             value: ttl_planes as f64 / battles as f64,
-        };
-        let exp: StatisticValueType<'_> = S::Exp {
+        }
+        .into();
+        let exp = S::Exp {
             value: ttl_exp as f64 / battles as f64,
-        };
+        }
+        .into();
         let pr = S::Pr {
             value: {
                 let n_wr = f64::max(0.0, ttl_wins as f64 / exp_ttl_wins - 0.7) / 0.3;
@@ -297,7 +302,8 @@ impl ShipStatsCollection {
                 let n_frags = f64::max(0.0, ttl_frags as f64 / exp_ttl_frags - 0.1) / 0.9;
                 Some(150.0 * n_wr + 700.0 * n_dmg + 300.0 * n_frags)
             },
-        };
+        }
+        .into();
         fn rounded_div(a: u64, b: u64) -> u64 {
             (a as f64 / b as f64).round() as u64
         }
@@ -305,9 +311,18 @@ impl ShipStatsCollection {
         let scout = rounded_div(ttl_scout, battles);
         let hitrate = (hits as f64 / shots as f64 * 10000.0).round() / 100.0; // two decimal places
 
-        Some(Statistic::new(
-            battles, winrate, dmg, frags, planes, pr, exp, potential, scout, hitrate,
-        ))
+        Some(Statistic {
+            battles,
+            winrate,
+            dmg,
+            frags,
+            planes,
+            pr,
+            exp,
+            potential,
+            scout,
+            hitrate,
+        })
     }
 }
 
@@ -361,29 +376,30 @@ impl ShipModeStatsPair {
         } else {
             0.0
         };
-        use StatisticValueType as S;
         let pr = expected_js.read().data.get(&ship_id.0).map(|expected| {
             let n_wr = f64::max(0.0, winrate / expected.winrate - 0.7) / 0.3;
             let n_dmg = f64::max(0.0, dmg / expected.dmg - 0.4) / 0.6;
             let n_frags = f64::max(0.0, frags / expected.frags - 0.1) / 0.9;
             150.0 * n_wr + 700.0 * n_dmg + 300.0 * n_frags
         });
-        Some(Statistic::new(
+        use StatisticValueType as S;
+        Some(Statistic {
             battles,
-            S::Winrate { value: winrate },
-            S::ShipDmg {
+            winrate: S::Winrate { value: winrate }.into(),
+            dmg: S::ShipDmg {
                 expected_js,
                 value: dmg,
                 ship_id,
-            },
-            S::Frags { value: frags },
-            S::Planes { value: planes },
-            S::Pr { value: pr },
-            S::Exp { value: exp },
-            potential.round() as u64,
-            scout.round() as u64,
+            }
+            .into(),
+            frags: S::Frags { value: frags }.into(),
+            planes: S::Planes { value: planes }.into(),
+            pr: S::Pr { value: pr }.into(),
+            exp: S::Exp { value: exp }.into(),
+            potential: potential.round() as u64,
+            scout: scout.round() as u64,
             hitrate,
-        ))
+        })
     }
 }
 

--- a/src/utils/structs/ship.rs
+++ b/src/utils/structs/ship.rs
@@ -274,23 +274,23 @@ impl ShipStatsCollection {
         if battles == 0 {
             return None;
         };
-        use StatisticValueType::*;
-        let winrate = Winrate {
+        use StatisticValueType as S;
+        let winrate = S::Winrate {
             value: ttl_wins as f64 / battles as f64 * 100.0,
         };
-        let dmg = OverallDmg {
+        let dmg = S::OverallDmg {
             value: ttl_dmg as f64 / battles as f64,
         };
-        let frags = Frags {
+        let frags = S::Frags {
             value: ttl_frags as f64 / battles as f64,
         };
-        let planes = Planes {
+        let planes = S::Planes {
             value: ttl_planes as f64 / battles as f64,
         };
-        let exp: StatisticValueType<'_> = Exp {
+        let exp: StatisticValueType<'_> = S::Exp {
             value: ttl_exp as f64 / battles as f64,
         };
-        let pr = Pr {
+        let pr = S::Pr {
             value: {
                 let n_wr = f64::max(0.0, ttl_wins as f64 / exp_ttl_wins - 0.7) / 0.3;
                 let n_dmg = f64::max(0.0, ttl_dmg as f64 / exp_ttl_dmg - 0.4) / 0.6;

--- a/src/utils/structs/ship.rs
+++ b/src/utils/structs/ship.rs
@@ -28,6 +28,7 @@ pub enum ShipClass {
     CV,
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, Deserialize_repr, Serialize, EnumIter, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum ShipTier {
@@ -93,14 +94,8 @@ impl Display for Ship {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct ShipStatsCollection(pub HashMap<ShipId, ShipModeStatsPair>);
-
-impl Default for ShipStatsCollection {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
 
 impl TryFrom<VortexShipResponse> for ShipStatsCollection {
     type Error = IsacError;
@@ -113,10 +108,10 @@ impl TryFrom<VortexShipResponse> for ShipStatsCollection {
             msg: "expected PlayerStats".to_owned(),
         })?;
         if player_stats.hidden_profile.is_some() || player_stats.statistics.is_none() {
-            return Err(IsacInfo::PlayerHidden {
+            Err(IsacInfo::PlayerHidden {
                 ign: player_stats.name.clone(),
             }
-            .into());
+            .into())
         } else {
             Ok(player_stats.statistics.take().unwrap()) // the if `statistics.is_none()` above already handle the None possibility
         }
@@ -127,7 +122,7 @@ impl ShipStatsCollection {
     /// merging the responses from vortex
     pub fn merge(mut self, mut other: Self) -> Self {
         for (ship_id, main_pair) in self.0.iter_mut() {
-            if let Some(sub_pair) = other.0.remove(&ship_id) {
+            if let Some(sub_pair) = other.0.remove(ship_id) {
                 main_pair.0.extend(sub_pair.0)
             }
         }
@@ -334,13 +329,8 @@ impl Display for ShipId {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(try_from = "JsonValue")]
+#[derive(Default)]
 pub struct ShipModeStatsPair(pub HashMap<Mode, ShipStats>);
-
-impl Default for ShipModeStatsPair {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
 
 impl ShipModeStatsPair {
     /// a shorcut of `self.0.get

--- a/src/utils/structs/statistic.rs
+++ b/src/utils/structs/statistic.rs
@@ -20,34 +20,6 @@ pub struct Statistic {
     pub hitrate: f64,
 }
 
-impl Statistic {
-    pub fn new<T: Into<StatisticValue>>(
-        battles: u64,
-        winrate: T,
-        dmg: T,
-        frags: T,
-        planes: T,
-        pr: T,
-        exp: T,
-        potential: u64,
-        scout: u64,
-        hitrate: f64,
-    ) -> Self {
-        Self {
-            battles,
-            winrate: winrate.into(),
-            dmg: dmg.into(),
-            frags: frags.into(),
-            planes: planes.into(),
-            pr: pr.into(),
-            exp: exp.into(),
-            potential,
-            scout,
-            hitrate,
-        }
-    }
-}
-
 // QA value actually can be u64 or f64, better way than String?
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StatisticValue {

--- a/src/utils/structs/statistic.rs
+++ b/src/utils/structs/statistic.rs
@@ -111,7 +111,7 @@ impl From<StatisticValueType<'_>> for StatisticValue {
     fn from(value: StatisticValueType<'_>) -> StatisticValue {
         let (value, color) = match value {
             StatisticValueType::Winrate { value } => {
-                const MAP: Lazy<Vec<(f64, &str)>> = Lazy::new(|| {
+                static MAP: Lazy<Vec<(f64, &str)>> = Lazy::new(|| {
                     vec![
                         (65.0, "#9d42f3"),
                         (60.0, "#d042f3"),
@@ -131,7 +131,7 @@ impl From<StatisticValueType<'_>> for StatisticValue {
                 (Self::_round_2(value).to_string(), color.to_string())
             }
             StatisticValueType::Frags { value } => {
-                const MAP: Lazy<Vec<(f64, &str)>> = Lazy::new(|| {
+                static MAP: Lazy<Vec<(f64, &str)>> = Lazy::new(|| {
                     vec![
                         (1.44, "#d042f3"),
                         (1.2, "#02c9b3"),
@@ -149,7 +149,7 @@ impl From<StatisticValueType<'_>> for StatisticValue {
                 (Self::_round_2(value).to_string(), color.to_string())
             }
             StatisticValueType::Planes { value } => {
-                const MAP: Lazy<Vec<(f64, &str)>> = Lazy::new(|| {
+                static MAP: Lazy<Vec<(f64, &str)>> = Lazy::new(|| {
                     vec![
                         (6.06, "#d042f3"),
                         (3.7, "#02c9b3"),
@@ -167,7 +167,7 @@ impl From<StatisticValueType<'_>> for StatisticValue {
                 (Self::_round_2(value).to_string(), color.to_string())
             }
             StatisticValueType::Pr { value } => {
-                const MAP: Lazy<Vec<(i64, &str)>> = Lazy::new(|| {
+                static MAP: Lazy<Vec<(i64, &str)>> = Lazy::new(|| {
                     vec![
                         (2450, "#9d42f3"),
                         (2100, "#d042f3"),
@@ -191,7 +191,7 @@ impl From<StatisticValueType<'_>> for StatisticValue {
                 }
             }
             StatisticValueType::OverallDmg { value } => {
-                const MAP: Lazy<Vec<(i64, &str)>> = Lazy::new(|| {
+                static MAP: Lazy<Vec<(i64, &str)>> = Lazy::new(|| {
                     vec![
                         (48500, "#d042f3"),
                         (38000, "#02c9b3"),
@@ -213,7 +213,7 @@ impl From<StatisticValueType<'_>> for StatisticValue {
                 value,
                 ship_id,
             } => {
-                const MAP: Lazy<Vec<(f64, &str)>> = Lazy::new(|| {
+                static MAP: Lazy<Vec<(f64, &str)>> = Lazy::new(|| {
                     vec![
                         (1.7, "#d042f3"),
                         (1.3, "#02c9b3"),
@@ -224,7 +224,7 @@ impl From<StatisticValueType<'_>> for StatisticValue {
                     ]
                 });
                 let color = if let Some(expected) = expected_js.read().data.get(&ship_id.0) {
-                    let normal_value = f64::max(0.0, value as f64 / expected.dmg - 0.4) / 0.6;
+                    let normal_value = f64::max(0.0, value / expected.dmg - 0.4) / 0.6;
                     MAP.iter()
                         .find(|(v, _)| &normal_value >= v)
                         .map(|(_, color)| *color)
@@ -236,7 +236,7 @@ impl From<StatisticValueType<'_>> for StatisticValue {
                 (Self::_round_int(value).to_string(), color.to_string())
             }
             StatisticValueType::Exp { value } => {
-                const MAP: Lazy<Vec<(i64, &str)>> = Lazy::new(|| {
+                static MAP: Lazy<Vec<(i64, &str)>> = Lazy::new(|| {
                     vec![
                         (1500, "#9d42f3"),
                         (1350, "#d042f3"),

--- a/src/utils/wws_api.rs
+++ b/src/utils/wws_api.rs
@@ -26,7 +26,7 @@ impl<'a> WowsApi<'a> {
         Self {
             client: &ctx.data().client,
             token: &ctx.data().wg_api_token,
-            data: &ctx.data(),
+            data: ctx.data(),
         }
     }
 
@@ -98,7 +98,7 @@ impl<'a> WowsApi<'a> {
         let mut res = self._get(url).await?.json::<ClanSearchRes>().await.unwrap();
         let clans = res.search_autocomplete_result.take().map(|clan| {
             clan.into_iter()
-                .map(|c| c.to_partial_clan(*region))
+                .map(|c| c.into_partial_clan(*region))
                 .collect::<Vec<_>>()
         });
 
@@ -263,8 +263,7 @@ impl<'a> WowsApi<'a> {
             .map_err(Self::_err_wrap)?
             .json::<ClanDetailRes>()
             .await
-            .unwrap()
-            .into();
+            .unwrap();
         clan_res.data()
     }
 }
@@ -321,7 +320,7 @@ struct ClanSearchResClan {
 }
 
 impl ClanSearchResClan {
-    fn to_partial_clan(self, region: Region) -> PartialClan {
+    fn into_partial_clan(self, region: Region) -> PartialClan {
         PartialClan {
             tag: self.tag,
             color: self.hex_color,

--- a/src/utils/wws_api.rs
+++ b/src/utils/wws_api.rs
@@ -66,8 +66,12 @@ impl<'a> WowsApi<'a> {
                 ign: ign.to_string(),
             })?
         }
-        let Ok(url) = region.vortex_url(format!("/api/accounts/search/autocomplete/{ign}/?limit={limit}")) else {
-            Err(IsacInfo::InvalidIgn { ign: ign.to_string() })?
+        let Ok(url) = region.vortex_url(format!(
+            "/api/accounts/search/autocomplete/{ign}/?limit={limit}"
+        )) else {
+            Err(IsacInfo::InvalidIgn {
+                ign: ign.to_string(),
+            })?
         };
         let res = self
             ._get(url)
@@ -84,8 +88,12 @@ impl<'a> WowsApi<'a> {
         region: &Region,
         clan_name: &str,
     ) -> Result<Vec<PartialClan>, IsacError> {
-        let Ok(url) = region.clan_url(format!("/api/search/autocomplete/?search={clan_name}&type=clans")) else {
-            Err(IsacInfo::InvalidClan { clan: clan_name.to_string() })?
+        let Ok(url) = region.clan_url(format!(
+            "/api/search/autocomplete/?search={clan_name}&type=clans"
+        )) else {
+            Err(IsacInfo::InvalidClan {
+                clan: clan_name.to_string(),
+            })?
         };
         let mut res = self._get(url).await?.json::<ClanSearchRes>().await.unwrap();
         let clans = res.search_autocomplete_result.take().map(|clan| {


### PR DESCRIPTION
<s>There are two instances of `clippy::too_many_arguments` remaining. Consider using builder pattern instead.</s>